### PR TITLE
Refactor/move sync calendar to base calendar handler

### DIFF
--- a/src/chronos/app_factory.py
+++ b/src/chronos/app_factory.py
@@ -143,7 +143,7 @@ class AppFactory:
         app_timezone = zoneinfo.ZoneInfo(self.app_config.get("app", "timezone"))
         all_calendars = self.source_readable_calendars + self.source_writable_calendars
         for calendar in all_calendars:
-            changed, deleted, new = self.sync_calendar(calendar)
+            changed, deleted, new = self.sync_calendar(calendar, self.target)
             calendar.last_check = dt.datetime.now().astimezone(app_timezone)
 
             msg = f'Done comparing with "{calendar.cal_name}". '
@@ -152,21 +152,21 @@ class AppFactory:
             msg += f"{len(deleted)} entries deleted."
             logger.success(msg)
 
-    def sync_calendar(self, cal_handler: BaseCalendarHandler) -> tuple[dict, dict, dict]:
+    def sync_calendar(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler) -> tuple[dict, dict, dict]:
         # Update target calendar events from source calendar
-        changed_events = self._update_target_events(cal_handler)
+        changed_events = self._update_target_events(cal_handler, target_cal_handler)
         # delete iCal event not in source calendar
-        deleted_events = self._delete_target_events(cal_handler)
+        deleted_events = self._delete_target_events(cal_handler, target_cal_handler)
         # create iCal event only in source calendar
-        new_events = self._create_target_events(cal_handler)
+        new_events = self._create_target_events(cal_handler, target_cal_handler)
 
         return changed_events, deleted_events, new_events
 
-    def _update_target_events(self, cal_handler: BaseCalendarHandler) -> dict:
+    def _update_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler) -> dict:
         """Update existing target calendar events"""
 
         source_events = cal_handler.get_events_data()
-        target_events = self.target.search_events_by_calid(cal_handler.chronos_id)
+        target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
         change_set = set(target_events).intersection(set(source_events))
         changed = {}
 
@@ -188,7 +188,7 @@ class AppFactory:
 
         return changed
 
-    def _delete_target_events(self, cal_handler: BaseCalendarHandler) -> dict:
+    def _delete_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler) -> dict:
         """delete target iCal events that are not in source calendar (any more)"""
 
         wipe_on_target = self.app_config.get("calendars", "delete_on_target")
@@ -196,7 +196,7 @@ class AppFactory:
             return {}
 
         source_events = cal_handler.get_events_data()
-        target_events = self.target.search_events_by_calid(cal_handler.chronos_id)
+        target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
         delete_set = set(target_events).difference(set(source_events))
         deleted = {}
 
@@ -212,11 +212,11 @@ class AppFactory:
 
         return deleted
 
-    def _create_target_events(self, cal_handler: BaseCalendarHandler) -> dict:
+    def _create_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler) -> dict:
         """create iCal events that are only in source calendar"""
 
         source_events = cal_handler.get_events_data()
-        target_events = self.target.search_events_by_calid(cal_handler.chronos_id)
+        target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
         new_set = set(source_events).difference(set(target_events))
         new_events: dict[icalendar.vText, BaseChronosEvent] = {}
 
@@ -242,7 +242,7 @@ class AppFactory:
 
                 _cal.add_component(vevent)
                 _new = _cal.to_ical()
-                self.target.calendar.add_event(_new, no_overwrite=True, no_create=False)
+                target_cal_handler.calendar.add_event(_new, no_overwrite=True, no_create=False)
                 logger.info(f"Created: {new_event.date} | {new_event.safe_title}")
                 new_events[event_id] = new_event
             except Exception as ex:

--- a/src/chronos/app_factory.py
+++ b/src/chronos/app_factory.py
@@ -14,15 +14,12 @@ import time
 import zoneinfo
 
 # external libs
-import icalendar
 from apscheduler.schedulers.background import BackgroundScheduler
 
 # own code
-from chronos.calendar_handlers.base_calendar_handler import BaseCalendarHandler
 from chronos.calendar_handlers.caldav_calendar_handler import CalDavCalendarHandler
 from chronos.calendar_handlers.ics_calendar_handler import IcsCalendarHandler
 from chronos.config import Config
-from chronos.events.base_chronos_event import BaseChronosEvent
 
 logger = logging.getLogger(__name__)
 

--- a/src/chronos/app_factory.py
+++ b/src/chronos/app_factory.py
@@ -185,7 +185,7 @@ class AppFactory:
             if source_event.last_modified > target_event.last_modified:
                 try:
                     # updated_event = target_event.update_calDaV_event(source_event)
-                    updated_event = cal_handler.update_remote_event(target_event, source_event)
+                    updated_event = target_cal_handler.update_remote_event(target_event, source_event)
                     changed[event_id] = updated_event
 
                     logger.info(f"Updated: {updated_event.date} | {updated_event.safe_title}")

--- a/src/chronos/app_factory.py
+++ b/src/chronos/app_factory.py
@@ -152,20 +152,21 @@ class AppFactory:
             msg += f"{len(deleted)} entries deleted."
             logger.success(msg)
 
-    def sync_calendar(self, calendar: BaseCalendarHandler) -> tuple[dict, dict, dict]:
+    def sync_calendar(self, cal_handler: BaseCalendarHandler) -> tuple[dict, dict, dict]:
         # Update target calendar events from source calendar
-        changed_events = self._update_target_events(calendar)
+        changed_events = self._update_target_events(cal_handler)
         # delete iCal event not in source calendar
-        deleted_events = self._delete_target_events(calendar)
+        deleted_events = self._delete_target_events(cal_handler)
         # create iCal event only in source calendar
-        new_events = self._create_target_events(calendar)
+        new_events = self._create_target_events(cal_handler)
+
         return changed_events, deleted_events, new_events
 
-    def _update_target_events(self, calendar: BaseCalendarHandler) -> dict:
+    def _update_target_events(self, cal_handler: BaseCalendarHandler) -> dict:
         """Update existing target calendar events"""
 
-        source_events = calendar.get_events_data()
-        target_events = self.target.search_events_by_calid(calendar.chronos_id)
+        source_events = cal_handler.get_events_data()
+        target_events = self.target.search_events_by_calid(cal_handler.chronos_id)
         change_set = set(target_events).intersection(set(source_events))
         changed = {}
 
@@ -178,7 +179,7 @@ class AppFactory:
             if source_event.last_modified > target_event.last_modified:
                 try:
                     # updated_event = target_event.update_calDaV_event(source_event)
-                    updated_event = calendar.update_remote_event(target_event, source_event)
+                    updated_event = cal_handler.update_remote_event(target_event, source_event)
                     changed[event_id] = updated_event
 
                     logger.info(f"Updated: {updated_event.date} | {updated_event.safe_title}")
@@ -187,15 +188,15 @@ class AppFactory:
 
         return changed
 
-    def _delete_target_events(self, calendar: BaseCalendarHandler) -> dict:
+    def _delete_target_events(self, cal_handler: BaseCalendarHandler) -> dict:
         """delete target iCal events that are not in source calendar (any more)"""
 
         wipe_on_target = self.app_config.get("calendars", "delete_on_target")
         if not wipe_on_target:
             return {}
 
-        source_events = calendar.get_events_data()
-        target_events = self.target.search_events_by_calid(calendar.chronos_id)
+        source_events = cal_handler.get_events_data()
+        target_events = self.target.search_events_by_calid(cal_handler.chronos_id)
         delete_set = set(target_events).difference(set(source_events))
         deleted = {}
 
@@ -211,11 +212,11 @@ class AppFactory:
 
         return deleted
 
-    def _create_target_events(self, calendar: BaseCalendarHandler) -> dict:
+    def _create_target_events(self, cal_handler: BaseCalendarHandler) -> dict:
         """create iCal events that are only in source calendar"""
 
-        source_events = calendar.get_events_data()
-        target_events = self.target.search_events_by_calid(calendar.chronos_id)
+        source_events = cal_handler.get_events_data()
+        target_events = self.target.search_events_by_calid(cal_handler.chronos_id)
         new_set = set(source_events).difference(set(target_events))
         new_events: dict[icalendar.vText, BaseChronosEvent] = {}
 
@@ -230,7 +231,7 @@ class AppFactory:
             if new_event.is_excluded:
                 logger.debug(f"Ignoring event excluded by tag: {new_event.date}")
                 continue
-            if (calendar.ignore_planned and new_event.is_planned) or new_event.is_canceled:
+            if (cal_handler.ignore_planned and new_event.is_planned) or new_event.is_canceled:
                 logger.debug(f"Ignoring {new_event.status} event: {new_event.date} | {new_event.safe_title}")
                 # skip planned events
                 continue

--- a/src/chronos/app_factory.py
+++ b/src/chronos/app_factory.py
@@ -141,9 +141,10 @@ class AppFactory:
 
     def sync_calendars(self) -> None:
         app_timezone = zoneinfo.ZoneInfo(self.app_config.get("app", "timezone"))
+        show_trace = self.app_config.get("log", "show_tracebacks")
         all_calendars = self.source_readable_calendars + self.source_writable_calendars
         for calendar in all_calendars:
-            changed, deleted, new = self.sync_calendar(calendar, self.target)
+            changed, deleted, new = self.sync_calendar(calendar, self.target, show_trace)
             calendar.last_check = dt.datetime.now().astimezone(app_timezone)
 
             msg = f'Done comparing with "{calendar.cal_name}". '
@@ -152,17 +153,22 @@ class AppFactory:
             msg += f"{len(deleted)} entries deleted."
             logger.success(msg)
 
-    def sync_calendar(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler) -> tuple[dict, dict, dict]:
+    def sync_calendar(
+        self,
+        cal_handler: BaseCalendarHandler,
+        target_cal_handler: CalDavCalendarHandler,
+        show_trace: bool,
+    ) -> tuple[dict, dict, dict]:
         # Update target calendar events from source calendar
-        changed_events = self._update_target_events(cal_handler, target_cal_handler)
+        changed_events = self._update_target_events(cal_handler, target_cal_handler, show_trace)
         # delete iCal event not in source calendar
-        deleted_events = self._delete_target_events(cal_handler, target_cal_handler)
+        deleted_events = self._delete_target_events(cal_handler, target_cal_handler, show_trace)
         # create iCal event only in source calendar
-        new_events = self._create_target_events(cal_handler, target_cal_handler)
+        new_events = self._create_target_events(cal_handler, target_cal_handler, show_trace)
 
         return changed_events, deleted_events, new_events
 
-    def _update_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler) -> dict:
+    def _update_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler, show_trace: bool) -> dict:
         """Update existing target calendar events"""
 
         source_events = cal_handler.get_events_data()
@@ -184,11 +190,11 @@ class AppFactory:
 
                     logger.info(f"Updated: {updated_event.date} | {updated_event.safe_title}")
                 except Exception as ex:
-                    logger.error(f"Could not update event: {ex}")
+                    logger.error(f"Could not update event: {ex}", exc_info=show_trace)
 
         return changed
 
-    def _delete_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler) -> dict:
+    def _delete_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler, show_trace: bool) -> dict:
         """delete target iCal events that are not in source calendar (any more)"""
 
         wipe_on_target = self.app_config.get("calendars", "delete_on_target")
@@ -208,11 +214,11 @@ class AppFactory:
                     logger.info(f"Deleted: {delete_event.date} | {delete_event.safe_title}")
                     deleted[event_id] = delete_event
             except Exception as ex:
-                logger.error(f"Could not delete obsolete event: {ex}")
+                logger.error(f"Could not delete obsolete event: {ex}", exc_info=show_trace)
 
         return deleted
 
-    def _create_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler) -> dict:
+    def _create_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler, show_trace: bool) -> dict:
         """create iCal events that are only in source calendar"""
 
         source_events = cal_handler.get_events_data()
@@ -246,7 +252,7 @@ class AppFactory:
                 logger.info(f"Created: {new_event.date} | {new_event.safe_title}")
                 new_events[event_id] = new_event
             except Exception as ex:
-                logger.error(f"Could not create new event: {ex}")
+                logger.error(f"Could not create new event: {ex}", exc_info=show_trace)
                 if new_event is not None and hasattr(new_event, "title") and hasattr(new_event, "date"):
                     logger.error(f"Affected event: {new_event.safe_title} {new_event.date}")
 

--- a/src/chronos/app_factory.py
+++ b/src/chronos/app_factory.py
@@ -144,7 +144,7 @@ class AppFactory:
         show_trace = self.app_config.get("log", "show_tracebacks")
         all_calendars = self.source_readable_calendars + self.source_writable_calendars
         for calendar in all_calendars:
-            changed, deleted, new = self.sync_calendar(calendar, self.target, show_trace)
+            changed, deleted, new = self.target.sync_calendar(calendar, self.target, show_trace)
             calendar.last_check = dt.datetime.now().astimezone(app_timezone)
 
             msg = f'Done comparing with "{calendar.cal_name}". '
@@ -152,108 +152,3 @@ class AppFactory:
             msg += f"{len(new)} entries added. "
             msg += f"{len(deleted)} entries deleted."
             logger.success(msg)
-
-    def sync_calendar(
-        self,
-        cal_handler: BaseCalendarHandler,
-        target_cal_handler: CalDavCalendarHandler,
-        show_trace: bool,
-    ) -> tuple[dict, dict, dict]:
-        # Update target calendar events from source calendar
-        changed_events = self._update_target_events(cal_handler, target_cal_handler, show_trace)
-        # delete iCal event not in source calendar
-        deleted_events = self._delete_target_events(cal_handler, target_cal_handler, show_trace)
-        # create iCal event only in source calendar
-        new_events = self._create_target_events(cal_handler, target_cal_handler, show_trace)
-
-        return changed_events, deleted_events, new_events
-
-    def _update_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler, show_trace: bool) -> dict:
-        """Update existing target calendar events"""
-
-        source_events = cal_handler.get_events_data()
-        target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
-        change_set = set(target_events).intersection(set(source_events))
-        changed: dict[str, BaseChronosEvent] = {}
-
-        for event_id in change_set:
-            target_event = target_events[event_id]
-            source_event = source_events[event_id]
-
-            # TODO: (Re)Implement respect remote changes
-            # if source_event.last_modified > target_event.last_modified and not target_event.remote_changed:
-            if source_event.last_modified > target_event.last_modified:
-                try:
-                    # updated_event = target_event.update_calDaV_event(source_event)
-                    updated_event = target_cal_handler.update_remote_event(target_event, source_event)
-                    changed[event_id] = updated_event
-
-                    logger.info(f"Updated: {updated_event.date} | {updated_event.safe_title}")
-                except Exception as ex:
-                    logger.error(f"Could not update event: {ex}", exc_info=show_trace)
-
-        return changed
-
-    def _delete_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler, show_trace: bool) -> dict:
-        """delete target iCal events that are not in source calendar (any more)"""
-
-        wipe_on_target = self.app_config.get("calendars", "delete_on_target")
-        if not wipe_on_target:
-            return {}
-
-        source_events = cal_handler.get_events_data()
-        target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
-        delete_set = set(target_events).difference(set(source_events))
-        deleted: dict[str, BaseChronosEvent] = {}
-
-        for event_id in delete_set:
-            try:
-                if target_events[event_id].is_chronos_origin:
-                    delete_event = target_events[event_id]
-                    delete_event.calDAV.delete()
-                    logger.info(f"Deleted: {delete_event.date} | {delete_event.safe_title}")
-                    deleted[event_id] = delete_event
-            except Exception as ex:
-                logger.error(f"Could not delete obsolete event: {ex}", exc_info=show_trace)
-
-        return deleted
-
-    def _create_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: CalDavCalendarHandler, show_trace: bool) -> dict:
-        """create iCal events that are only in source calendar"""
-
-        source_events = cal_handler.get_events_data()
-        target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
-        new_set = set(source_events).difference(set(target_events))
-        new_events: dict[str, BaseChronosEvent] = {}
-
-        for event_id in new_set:
-            new_event = source_events[event_id]
-            if not (new_event.has_title):
-                logger.debug(f"Ignoring event without title: {new_event.date}")
-                continue
-            if new_event.is_confidential:
-                logger.debug(f"Ignoring confidential event: {new_event.date}")
-                continue
-            if new_event.is_excluded:
-                logger.debug(f"Ignoring event excluded by tag: {new_event.date}")
-                continue
-            if (cal_handler.ignore_planned and new_event.is_planned) or new_event.is_canceled:
-                logger.debug(f"Ignoring {new_event.status} event: {new_event.date} | {new_event.safe_title}")
-                # skip planned events
-                continue
-
-            try:
-                _cal = icalendar.Calendar()
-                vevent = new_event.create_ical_event()
-
-                _cal.add_component(vevent)
-                _new = _cal.to_ical()
-                target_cal_handler.calendar.add_event(_new, no_overwrite=True, no_create=False)
-                logger.info(f"Created: {new_event.date} | {new_event.safe_title}")
-                new_events[event_id] = new_event
-            except Exception as ex:
-                logger.error(f"Could not create new event: {ex}", exc_info=show_trace)
-                if new_event is not None and hasattr(new_event, "title") and hasattr(new_event, "date"):
-                    logger.error(f"Affected event: {new_event.safe_title} {new_event.date}")
-
-        return new_events

--- a/src/chronos/app_factory.py
+++ b/src/chronos/app_factory.py
@@ -144,7 +144,7 @@ class AppFactory:
         show_trace = self.app_config.get("log", "show_tracebacks")
         all_calendars = self.source_readable_calendars + self.source_writable_calendars
         for calendar in all_calendars:
-            changed, deleted, new = self.target.sync_calendar(calendar, self.target, show_trace)
+            changed, deleted, new = self.target.sync_calendar(calendar, show_trace)
             calendar.last_check = dt.datetime.now().astimezone(app_timezone)
 
             msg = f'Done comparing with "{calendar.cal_name}". '

--- a/src/chronos/app_factory.py
+++ b/src/chronos/app_factory.py
@@ -174,7 +174,7 @@ class AppFactory:
         source_events = cal_handler.get_events_data()
         target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
         change_set = set(target_events).intersection(set(source_events))
-        changed = {}
+        changed: dict[str, BaseChronosEvent] = {}
 
         for event_id in change_set:
             target_event = target_events[event_id]
@@ -204,7 +204,7 @@ class AppFactory:
         source_events = cal_handler.get_events_data()
         target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
         delete_set = set(target_events).difference(set(source_events))
-        deleted = {}
+        deleted: dict[str, BaseChronosEvent] = {}
 
         for event_id in delete_set:
             try:
@@ -224,7 +224,7 @@ class AppFactory:
         source_events = cal_handler.get_events_data()
         target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
         new_set = set(source_events).difference(set(target_events))
-        new_events: dict[icalendar.vText, BaseChronosEvent] = {}
+        new_events: dict[str, BaseChronosEvent] = {}
 
         for event_id in new_set:
             new_event = source_events[event_id]

--- a/src/chronos/calendar_handlers/base_calendar_handler.py
+++ b/src/chronos/calendar_handlers/base_calendar_handler.py
@@ -25,10 +25,6 @@ class BaseCalendarHandler(abc.ABC):
         self.last_check = (dt.datetime.now() - dt.timedelta(days=7)).astimezone(app_timezone)
         self.cal_timezone_info = zoneinfo.ZoneInfo("UTC")
 
-        self.client = None
-        self.calendar = None
-        self.principal = None
-
         # derived from calendars.json
         self.cal_primary = None
         self.cal_name = None

--- a/src/chronos/calendar_handlers/caldav_calendar_handler.py
+++ b/src/chronos/calendar_handlers/caldav_calendar_handler.py
@@ -210,26 +210,21 @@ class CalDavCalendarHandler(BaseCalendarHandler):
         if self.client is not None:
             self.client.close()
 
-    def sync_calendar(
-        self,
-        cal_handler: BaseCalendarHandler,
-        target_cal_handler: "CalDavCalendarHandler",
-        show_trace: bool,
-    ) -> tuple[dict, dict, dict]:
+    def sync_calendar(self, cal_handler: BaseCalendarHandler, show_trace: bool) -> tuple[dict, dict, dict]:
         # Update target calendar events from source calendar
-        changed_events = self._update_target_events(cal_handler, target_cal_handler, show_trace)
+        changed_events = self._update_target_events(cal_handler, show_trace)
         # delete iCal event not in source calendar
-        deleted_events = self._delete_target_events(cal_handler, target_cal_handler, show_trace)
+        deleted_events = self._delete_target_events(cal_handler, show_trace)
         # create iCal event only in source calendar
-        new_events = self._create_target_events(cal_handler, target_cal_handler, show_trace)
+        new_events = self._create_target_events(cal_handler, show_trace)
 
         return changed_events, deleted_events, new_events
 
-    def _update_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: "CalDavCalendarHandler", show_trace: bool) -> dict:
+    def _update_target_events(self, cal_handler: BaseCalendarHandler, show_trace: bool) -> dict:
         """Update existing target calendar events"""
 
         source_events = cal_handler.get_events_data()
-        target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
+        target_events = self.search_events_by_calid(cal_handler.chronos_id)
         change_set = set(target_events).intersection(set(source_events))
         changed: dict[str, BaseChronosEvent] = {}
 
@@ -242,7 +237,7 @@ class CalDavCalendarHandler(BaseCalendarHandler):
             if source_event.last_modified > target_event.last_modified:
                 try:
                     # updated_event = target_event.update_calDaV_event(source_event)
-                    updated_event = target_cal_handler.update_remote_event(target_event, source_event)
+                    updated_event = self.update_remote_event(target_event, source_event)
                     changed[event_id] = updated_event
 
                     logger.info(f"Updated: {updated_event.date} | {updated_event.safe_title}")
@@ -251,7 +246,7 @@ class CalDavCalendarHandler(BaseCalendarHandler):
 
         return changed
 
-    def _delete_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: "CalDavCalendarHandler", show_trace: bool) -> dict:
+    def _delete_target_events(self, cal_handler: BaseCalendarHandler, show_trace: bool) -> dict:
         """delete target iCal events that are not in source calendar (any more)"""
 
         wipe_on_target = self.app_config.get("calendars", "delete_on_target")
@@ -259,7 +254,7 @@ class CalDavCalendarHandler(BaseCalendarHandler):
             return {}
 
         source_events = cal_handler.get_events_data()
-        target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
+        target_events = self.search_events_by_calid(cal_handler.chronos_id)
         delete_set = set(target_events).difference(set(source_events))
         deleted: dict[str, BaseChronosEvent] = {}
 
@@ -275,11 +270,11 @@ class CalDavCalendarHandler(BaseCalendarHandler):
 
         return deleted
 
-    def _create_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: "CalDavCalendarHandler", show_trace: bool) -> dict:
+    def _create_target_events(self, cal_handler: BaseCalendarHandler, show_trace: bool) -> dict:
         """create iCal events that are only in source calendar"""
 
         source_events = cal_handler.get_events_data()
-        target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
+        target_events = self.search_events_by_calid(cal_handler.chronos_id)
         new_set = set(source_events).difference(set(target_events))
         new_events: dict[str, BaseChronosEvent] = {}
 
@@ -305,7 +300,7 @@ class CalDavCalendarHandler(BaseCalendarHandler):
 
                 _cal.add_component(vevent)
                 _new = _cal.to_ical()
-                target_cal_handler.calendar.add_event(_new, no_overwrite=True, no_create=False)
+                self.calendar.add_event(_new, no_overwrite=True, no_create=False)
                 logger.info(f"Created: {new_event.date} | {new_event.safe_title}")
                 new_events[event_id] = new_event
             except Exception as ex:

--- a/src/chronos/calendar_handlers/caldav_calendar_handler.py
+++ b/src/chronos/calendar_handlers/caldav_calendar_handler.py
@@ -27,9 +27,9 @@ class CalDavCalendarHandler(BaseCalendarHandler):
     def __init__(self, app_config: Config):
         super().__init__(app_config)
 
-        self.client: davclient.DAVClient
+        self.client: caldav.davclient.DAVClient
         self.calendar: caldav.collection.Calendar
-        self.principal: davclient.Principal
+        self.principal: caldav.davclient.Principal
 
         self.writable_events: dict[str, CalDavChronosEvent] = {}
 

--- a/src/chronos/calendar_handlers/caldav_calendar_handler.py
+++ b/src/chronos/calendar_handlers/caldav_calendar_handler.py
@@ -8,6 +8,8 @@ import zoneinfo
 
 # external libs
 import caldav
+import caldav.collection
+import caldav.davclient
 import icalendar
 from icalendar import vDDDTypes as icalDate
 from icalendar.prop import vCategory
@@ -24,6 +26,10 @@ logger = logging.getLogger(__name__)
 class CalDavCalendarHandler(BaseCalendarHandler):
     def __init__(self, app_config: Config):
         super().__init__(app_config)
+
+        self.client: davclient.DAVClient
+        self.calendar: caldav.collection.Calendar
+        self.principal: davclient.Principal
 
         self.writable_events: dict[str, CalDavChronosEvent] = {}
 
@@ -42,7 +48,7 @@ class CalDavCalendarHandler(BaseCalendarHandler):
     def sanitize_icons_tgt(self) -> bool:
         return self.sanitize["target_icons"]
 
-    def available_calendars(self) -> list[caldav.Calendar]:
+    def available_calendars(self) -> list[caldav.collection.Calendar]:
         calendars = self.principal.calendars()
         logger.info(f"Fetching available calendars on: {self.cal_name}")
         logger.debug("Found:")
@@ -67,8 +73,12 @@ class CalDavCalendarHandler(BaseCalendarHandler):
 
         start = time.time()
         try:
-            self.client = caldav.DAVClient(self.cal_primary, username=self.cal_user, password=self.cal_passwd)
-            self.principal = self.client.principal()
+            self.client = caldav.davclient.DAVClient(
+                url=self.cal_primary,
+                username=self.cal_user,
+                password=self.cal_passwd,
+            )
+            self.principal = self.client.get_principal()
         except Exception as ex:
             logger.critical(f"Error on CALDav auth: {ex}")
             raise
@@ -126,7 +136,7 @@ class CalDavCalendarHandler(BaseCalendarHandler):
         if self.calendar is None:
             raise ValueError(f"read_from_cal_dav: target calendar '{self.cal_name}' was not found!")
 
-    def read_event(self, calEvent: caldav.Event) -> None:
+    def read_event(self, calEvent: caldav.collection.Event) -> None:
         """read event data"""
         # TODO: Clean this mess. As there should only be one vevent component. at least if caldav filter is working
         cal = icalendar.Calendar.from_ical(calEvent.data)

--- a/src/chronos/calendar_handlers/caldav_calendar_handler.py
+++ b/src/chronos/calendar_handlers/caldav_calendar_handler.py
@@ -295,12 +295,12 @@ class CalDavCalendarHandler(BaseCalendarHandler):
                 continue
 
             try:
-                _cal = icalendar.Calendar()
-                vevent = new_event.create_ical_event()
+                tmp_cal = icalendar.Calendar()
+                vevent: icalendar.Event = new_event.create_ical_event()
 
-                _cal.add_component(vevent)
-                _new = _cal.to_ical()
-                self.calendar.add_event(_new, no_overwrite=True, no_create=False)
+                tmp_cal.add_component(vevent)
+                new_ical_raw_text: bytes = tmp_cal.to_ical()
+                self.calendar.add_event(new_ical_raw_text, no_overwrite=True, no_create=False)
                 logger.info(f"Created: {new_event.date} | {new_event.safe_title}")
                 new_events[event_id] = new_event
             except Exception as ex:

--- a/src/chronos/calendar_handlers/caldav_calendar_handler.py
+++ b/src/chronos/calendar_handlers/caldav_calendar_handler.py
@@ -209,3 +209,108 @@ class CalDavCalendarHandler(BaseCalendarHandler):
     def close_connection(self) -> None:
         if self.client is not None:
             self.client.close()
+
+    def sync_calendar(
+        self,
+        cal_handler: BaseCalendarHandler,
+        target_cal_handler: "CalDavCalendarHandler",
+        show_trace: bool,
+    ) -> tuple[dict, dict, dict]:
+        # Update target calendar events from source calendar
+        changed_events = self._update_target_events(cal_handler, target_cal_handler, show_trace)
+        # delete iCal event not in source calendar
+        deleted_events = self._delete_target_events(cal_handler, target_cal_handler, show_trace)
+        # create iCal event only in source calendar
+        new_events = self._create_target_events(cal_handler, target_cal_handler, show_trace)
+
+        return changed_events, deleted_events, new_events
+
+    def _update_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: "CalDavCalendarHandler", show_trace: bool) -> dict:
+        """Update existing target calendar events"""
+
+        source_events = cal_handler.get_events_data()
+        target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
+        change_set = set(target_events).intersection(set(source_events))
+        changed: dict[str, BaseChronosEvent] = {}
+
+        for event_id in change_set:
+            target_event = target_events[event_id]
+            source_event = source_events[event_id]
+
+            # TODO: (Re)Implement respect remote changes
+            # if source_event.last_modified > target_event.last_modified and not target_event.remote_changed:
+            if source_event.last_modified > target_event.last_modified:
+                try:
+                    # updated_event = target_event.update_calDaV_event(source_event)
+                    updated_event = target_cal_handler.update_remote_event(target_event, source_event)
+                    changed[event_id] = updated_event
+
+                    logger.info(f"Updated: {updated_event.date} | {updated_event.safe_title}")
+                except Exception as ex:
+                    logger.error(f"Could not update event: {ex}", exc_info=show_trace)
+
+        return changed
+
+    def _delete_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: "CalDavCalendarHandler", show_trace: bool) -> dict:
+        """delete target iCal events that are not in source calendar (any more)"""
+
+        wipe_on_target = self.app_config.get("calendars", "delete_on_target")
+        if not wipe_on_target:
+            return {}
+
+        source_events = cal_handler.get_events_data()
+        target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
+        delete_set = set(target_events).difference(set(source_events))
+        deleted: dict[str, BaseChronosEvent] = {}
+
+        for event_id in delete_set:
+            try:
+                if target_events[event_id].is_chronos_origin:
+                    delete_event = target_events[event_id]
+                    delete_event.calDAV.delete()
+                    logger.info(f"Deleted: {delete_event.date} | {delete_event.safe_title}")
+                    deleted[event_id] = delete_event
+            except Exception as ex:
+                logger.error(f"Could not delete obsolete event: {ex}", exc_info=show_trace)
+
+        return deleted
+
+    def _create_target_events(self, cal_handler: BaseCalendarHandler, target_cal_handler: "CalDavCalendarHandler", show_trace: bool) -> dict:
+        """create iCal events that are only in source calendar"""
+
+        source_events = cal_handler.get_events_data()
+        target_events = target_cal_handler.search_events_by_calid(cal_handler.chronos_id)
+        new_set = set(source_events).difference(set(target_events))
+        new_events: dict[str, BaseChronosEvent] = {}
+
+        for event_id in new_set:
+            new_event = source_events[event_id]
+            if not (new_event.has_title):
+                logger.debug(f"Ignoring event without title: {new_event.date}")
+                continue
+            if new_event.is_confidential:
+                logger.debug(f"Ignoring confidential event: {new_event.date}")
+                continue
+            if new_event.is_excluded:
+                logger.debug(f"Ignoring event excluded by tag: {new_event.date}")
+                continue
+            if (cal_handler.ignore_planned and new_event.is_planned) or new_event.is_canceled:
+                logger.debug(f"Ignoring {new_event.status} event: {new_event.date} | {new_event.safe_title}")
+                # skip planned events
+                continue
+
+            try:
+                _cal = icalendar.Calendar()
+                vevent = new_event.create_ical_event()
+
+                _cal.add_component(vevent)
+                _new = _cal.to_ical()
+                target_cal_handler.calendar.add_event(_new, no_overwrite=True, no_create=False)
+                logger.info(f"Created: {new_event.date} | {new_event.safe_title}")
+                new_events[event_id] = new_event
+            except Exception as ex:
+                logger.error(f"Could not create new event: {ex}", exc_info=show_trace)
+                if new_event is not None and hasattr(new_event, "title") and hasattr(new_event, "date"):
+                    logger.error(f"Affected event: {new_event.safe_title} {new_event.date}")
+
+        return new_events


### PR DESCRIPTION
- fix recent regression in `_update_target_events` (it was "writing" to the source instead of target calendar)
- move `sync_calendar` from `AppFactory` to `CalDavCalendarHandler`
- add parameter `show_trace` to steer verbose on exceptions from the callers side